### PR TITLE
shows all 6 sides rotating

### DIFF
--- a/src/components/About/index.scss
+++ b/src/components/About/index.scss
@@ -64,10 +64,10 @@
     transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg);
   }
   16% {
-    transform: rotateY(-90deg);
+    transform: rotateY(-90deg) rotateZ(90deg);
   }
   33% {
-    transform: rotateY(-90deg) rotateZ(90deg);
+    transform: rotateY(-90deg) rotateX(90deg);
   }
   50% {
     transform: rotateY(-180deg) rotateZ(90deg);


### PR DESCRIPTION
Previous code's cube rotates but doesn't show 2 sides in the beginning (and sometimes not at all). I played around with the code and figured out the spincube was missing the corresponding rotateZ & rotateX's to show all 6 sides during continuous rotation.